### PR TITLE
refactor: move qft builder to `builders.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ uv sync
 3. Execute `main` script as a demo (requires GPU).
 
 ```shell
-cd src
+cd src/tensor_equiv
 uv run python main.py
 ```

--- a/src/tensor_equiv/__init__.py
+++ b/src/tensor_equiv/__init__.py
@@ -3,6 +3,7 @@ from .builders import (
     get_n_bell_pairs_circuit,
     get_choi_state_circuit,
     get_diagonal_choi_state_circuit,
+    build_qft_circuit,
 )
 
 
@@ -22,4 +23,5 @@ __all__ = [
     "check_equivalence",
     "check_equivalence_with_ancillas",
     "REPLACE_CONDITIONALS",
+    "build_qft_circuit",
 ]

--- a/src/tensor_equiv/builders.py
+++ b/src/tensor_equiv/builders.py
@@ -8,6 +8,17 @@ from pytket.circuit import DiagonalBox, CircBox
 from pytket.passes import DecomposeBoxes
 
 
+def build_qft_circuit(n_qubits: int) -> Circuit:
+    circ = Circuit(n_qubits, name="$$QFT$$")
+    for i in range(n_qubits):
+        circ.H(i)
+        for j in range(i + 1, n_qubits):
+            circ.CU1(1 / 2 ** (j - i), j, i)
+    for k in range(0, n_qubits // 2):
+        circ.SWAP(k, n_qubits - k - 1)
+    return circ
+
+
 def get_n_bell_pairs_circuit(
     n_bell_pairs: int, control_name: str, target_name: str
 ) -> Circuit:

--- a/src/tensor_equiv/main.py
+++ b/src/tensor_equiv/main.py
@@ -9,24 +9,13 @@ Requires GPU for execution.
 from topt_proto.gadgetisation import (
     REPLACE_HADAMARDS,
 )
-from pytket.circuit import Circuit
 from pytket.passes import ComposePhasePolyBoxes
 
+from .builders import build_qft_circuit
 from .checkers import check_equivalence_with_ancillas
 from .preprocess import REPLACE_CONDITIONALS
 
 import time
-
-
-def build_qft_circuit(n_qubits: int) -> Circuit:
-    circ = Circuit(n_qubits, name="$$QFT$$")
-    for i in range(n_qubits):
-        circ.H(i)
-        for j in range(i + 1, n_qubits):
-            circ.CU1(1 / 2 ** (j - i), j, i)
-    for k in range(0, n_qubits // 2):
-        circ.SWAP(k, n_qubits - k - 1)
-    return circ
 
 
 def main():

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -6,8 +6,11 @@ from pytket.circuit import Circuit, OpType
 from pytket.utils import compare_statevectors
 from pytket.passes import ComposePhasePolyBoxes
 
-from tensor_equiv.builders import get_choi_state_circuit, get_ancilla_check_circuit
-from tensor_equiv.main import build_qft_circuit
+from tensor_equiv.builders import (
+    get_choi_state_circuit,
+    get_ancilla_check_circuit,
+    build_qft_circuit,
+)
 from tensor_equiv.preprocess import REPLACE_CONDITIONALS
 
 from topt_proto.gadgetisation import REPLACE_HADAMARDS, get_n_internal_hadamards


### PR DESCRIPTION
Makes more sense to have it here rather than import the QFT from the main file for testing.

Also a minor README fix.